### PR TITLE
Allow new minor versions of will_paginate-bootstrap-style, fix GitHub repo in gemspec

### DIFF
--- a/caffeinate_webui.gemspec
+++ b/caffeinate_webui.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
   spec.version     = Caffeinate::Webui::VERSION
   spec.authors     = ['joshmn']
   spec.email       = ['josh@josh.mn']
-  spec.homepage    = 'https://github.com/joshmn/caffeinate_webui'
+  spec.homepage    = 'https://github.com/joshmn/caffeinate-webui'
   spec.summary     = 'Create, manage, and send scheduled email sequences and drip campaigns from your Rails app.'
   spec.description = spec.summary
   spec.license     = 'MIT'

--- a/caffeinate_webui.gemspec
+++ b/caffeinate_webui.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'sprockets-rails'
   spec.add_dependency 'groupdate', '>= 5'
   spec.add_dependency 'chartkick', '>= 4'
-  spec.add_dependency 'will_paginate-bootstrap-style', '0.2.4'
+  spec.add_dependency 'will_paginate-bootstrap-style', '~> 0.2'
   spec.add_dependency 'will_paginate', '>= 3'
 
   spec.add_development_dependency 'pry'


### PR DESCRIPTION
will_paginate-bootstrap-style version 0.3.0 uses will_paginate v4+, which has tested compatibility
with the latest Ruby / Rails versions.

https://github.com/delef/will_paginate-bootstrap-style/compare/v0.2.4...v0.3.0
https://github.com/mislav/will_paginate/releases/tag/v4.0.0
https://github.com/mislav/will_paginate/releases/tag/v4.0.1

Also fixed the homepage in gemspec, it was 404'ing.

---
This will help with some dependency updates. Hopefully we could get a new patch release with these changes? I'm happy to update the version and everything, didn't want to do that ahead of time.